### PR TITLE
Fixed Off-by-one error. Producing incorrect result in the Part01 Func…

### DIFF
--- a/day02/part01.go
+++ b/day02/part01.go
@@ -35,7 +35,8 @@ func Part01(input string) {
 
 	for _, line := range utils.SplitLines(input) {
 		if isGameLineGood(line) {
-			sumOfGID += lineCount + 1
+			// sumOfGID += lineCount + 1  // Produces incorrect result
+			sumOfGID += lineCount // Fix was by removing + 1
 			goodGames++
 		}
 		lineCount++


### PR DESCRIPTION
There was a user error in the the code producing incorrect result. We are trying to find the sum of the possible good games. Which according to the description was 3 which produces 8. The reason for this is that when you add + 1, you are actually incrementing the game ID by 1 for each good game. The game IDs start from 1, so if you add 1 for each good game, you end up with an incorrect sum. In the below snippet of the function I have removed the + 1 increment. Which solves this problem.

```go
func Part01(input string) {
	sumOfGID, goodGames, lineCount := 0, 0, 1

	for _, line := range utils.SplitLines(input) {
		if isGameLineGood(line) {
			sumOfGID += lineCount  // removed the + 1
			goodGames++
		}
		lineCount++
	}

	fmt.Printf("There are %d possible games and their sum-score is %d\n", goodGames, sumOfGID)
}
```